### PR TITLE
Add completion event support to H5P activity

### DIFF
--- a/mod/h5pactivity/lib.php
+++ b/mod/h5pactivity/lib.php
@@ -29,42 +29,58 @@ use mod_h5pactivity\local\grader;
 use mod_h5pactivity\xapi\handler;
 
 /**
- * Refresh all module events for completion tracking.
+ * Rebuilds the completion–due calendar events for H5P activities.
  *
- * This allows the calendar events related to completion expected dates to be
- * rebuilt during actions such as course reset or restore.
+ * This is invoked by core cron (refresh_mod_calendar_events_task),
+ * by course restore, and by module duplication.
  *
- * @param int $courseid Course id to limit the refresh to
- * @param int|stdClass|null $instance Specific instance to refresh
- * @param int $userid Unused
- * @param int $groupid Unused
- * @return bool
+ * @param int        $courseid  zero = any course
+ * @param int|stdClass|null $instance  activity id **or** full record **or** null
+ * @param int        $userid    (unused)
+ * @param int        $groupid   (unused)
+ * @return bool always true
  */
-function h5pactivity_refresh_events($courseid = 0, $instance = null, $userid = 0, $groupid = 0) {
+function h5pactivity_refresh_events($courseid = 0,
+                                    $instance = null,
+                                    $userid   = 0,
+                                    $groupid  = 0) : bool {
     global $DB;
-    
-    $instanceid = null;
+
+    // 1. Build the list of H5P records we need to process.
     if ($instance) {
-        $instanceid = is_object($instance) ? $instance->id : (int)$instance;
-    }
-    
-    if ($instance) {
-        $records = [$DB->get_record('h5pactivity', ['id' => $instance], '*', MUST_EXIST)];
+        if (is_object($instance)) {
+            // The caller already provided the full record (duplication path).
+            $records = [$instance];
+        } else {
+            // Caller gave us just an id.
+            $records = [$DB->get_record('h5pactivity',
+                         ['id' => (int)$instance], '*', MUST_EXIST)];
+        }
     } else {
-        $records = $DB->get_records('h5pactivity', $courseid ? ['course' => $courseid] : []);
+        // Refresh the whole course or whole site.
+        $records = $DB->get_records('h5pactivity',
+                     $courseid ? ['course' => $courseid] : []);
     }
 
+    // 2. For each activity build / update the calendar event.
     foreach ($records as $h5p) {
-        $cm = get_coursemodule_from_instance('h5pactivity', $h5p->id, $h5p->course);
-        $completiontime = $h5p->completionexpected ?: null;
-        \core_completion\api::update_completion_date_event(
-            $cm->id,
-            'h5pactivity',
-            $h5p->id,
-            $completiontime
-        );
-    }
+        if (!$h5p) {                // safety
+            continue;
+        }
 
+        $cm = get_coursemodule_from_instance('h5pactivity',
+                                             $h5p->id,
+                                             $h5p->course,
+                                             false,
+                                             MUST_EXIST);
+
+        $completiontime = empty($h5p->completionexpected)
+                            ? null
+                            : (int)$h5p->completionexpected;
+
+        \core_completion\api::update_completion_date_event(
+                $cm->id, 'h5pactivity', $h5p->id, $completiontime);
+    }
     return true;
 }
 

--- a/mod/h5pactivity/lib.php
+++ b/mod/h5pactivity/lib.php
@@ -29,6 +29,84 @@ use mod_h5pactivity\local\grader;
 use mod_h5pactivity\xapi\handler;
 
 /**
+ * Refresh all module events for completion tracking.
+ *
+ * This allows the calendar events related to completion expected dates to be
+ * rebuilt during actions such as course reset or restore.
+ *
+ * @param int $courseid Course id to limit the refresh to
+ * @param int|stdClass|null $instance Specific instance to refresh
+ * @param int $userid Unused
+ * @param int $groupid Unused
+ * @return bool
+ */
+function h5pactivity_refresh_events($courseid = 0, $instance = null, $userid = 0, $groupid = 0) {
+    global $DB;
+
+    if ($instance) {
+        $records = [$DB->get_record('h5pactivity', ['id' => $instance], '*', MUST_EXIST)];
+    } else {
+        $records = $DB->get_records('h5pactivity', $courseid ? ['course' => $courseid] : []);
+    }
+
+    foreach ($records as $h5p) {
+        $cm = get_coursemodule_from_instance('h5pactivity', $h5p->id, $h5p->course);
+        $completiontime = $h5p->completionexpected ?: null;
+        \core_completion\api::update_completion_date_event(
+            $cm->id,
+            'h5pactivity',
+            $h5p->id,
+            $completiontime
+        );
+    }
+
+    return true;
+}
+
+/**
+ * Provide the event action for calendar events.
+ *
+ * @param calendar_event $event The calendar event
+ * @param \core_calendar\action_factory $factory The factory to create the action
+ * @param int $userid Optional user id, defaults to current user
+ * @return \core_calendar\local\event\value_objects\action|null
+ */
+function mod_h5pactivity_core_calendar_provide_event_action(
+    calendar_event $event,
+    \core_calendar\action_factory $factory,
+    int $userid = 0
+) : ?\core_calendar\local\event\value_objects\action {
+    global $USER;
+
+    if (!$userid) {
+        $userid = $USER->id;
+    }
+
+    $modinfo = get_fast_modinfo($event->courseid);
+    if (empty($modinfo->instances['h5pactivity'][$event->instance])) {
+        return null;
+    }
+    $cm = $modinfo->instances['h5pactivity'][$event->instance];
+    if (!$cm->uservisible) {
+        return null;
+    }
+
+    $completion = new completion_info($modinfo->get_course());
+    if ($completion->is_enabled($cm) &&
+            $completion->get_data($cm, false, $userid)->completionstate == COMPLETION_COMPLETE) {
+        return null;
+    }
+
+    $url = new moodle_url('/mod/h5pactivity/view.php', ['id' => $cm->id]);
+    return $factory->create_instance(
+        get_string('view'),
+        $url,
+        $event->timestart,
+        true
+    );
+}
+
+/**
  * Checks if H5P activity supports a specific feature.
  *
  * @uses FEATURE_GROUPS
@@ -98,6 +176,10 @@ function h5pactivity_add_instance(stdClass $data, ?mod_h5pactivity_mod_form $mfo
     // Extra fields required in grade related functions.
     $data->cmid = $data->coursemodule;
     h5pactivity_grade_item_update($data);
+
+    $completiontime = empty($data->completionexpected) ? null : $data->completionexpected;
+    \core_completion\api::update_completion_date_event(
+            $cmid, 'h5pactivity', $data->id, $completiontime);
     return $data->id;
 }
 
@@ -129,7 +211,13 @@ function h5pactivity_update_instance(stdClass $data, ?mod_h5pactivity_mod_form $
         h5pactivity_grade_item_update($data);
     }
 
-    return $DB->update_record('h5pactivity', $data);
+    $ok = $DB->update_record('h5pactivity', $data);
+
+    $completiontime = empty($data->completionexpected) ? null : $data->completionexpected;
+    \core_completion\api::update_completion_date_event(
+            $data->coursemodule, 'h5pactivity', $data->id, $completiontime);
+
+    return $ok;
 }
 
 /**

--- a/mod/h5pactivity/lib.php
+++ b/mod/h5pactivity/lib.php
@@ -42,7 +42,12 @@ use mod_h5pactivity\xapi\handler;
  */
 function h5pactivity_refresh_events($courseid = 0, $instance = null, $userid = 0, $groupid = 0) {
     global $DB;
-
+    
+    $instanceid = null;
+    if ($instance) {
+        $instanceid = is_object($instance) ? $instance->id : (int)$instance;
+    }
+    
     if ($instance) {
         $records = [$DB->get_record('h5pactivity', ['id' => $instance], '*', MUST_EXIST)];
     } else {


### PR DESCRIPTION
## Add calendar & timeline support for H5P “completionexpected” dates

**Closes issue:** Moodle-Tracker 79271

### Problem

H5P activities with a `completionexpected` timestamp were never inserted into **mdl\_event**, so they didn’t show up in:

* **Calendar**
* **Upcoming events**
* **Timeline** (Dashboard → My overview)

### What this patch does

1. **Helper to rebuild events**

   * Adds `h5pactivity_refresh_events()` so the core scheduled task (`refresh_mod_calendar_events_task`) can regenerate any missing “due‐date” events site-wide.
   * Fixes its signature to accept either an `id` or the full `stdClass` record.

2. **Automatic event creation & update**

   * In `h5pactivity_add_instance()`, calls

     ```php
     \core_completion\api::update_completion_date_event($cmid, 'h5pactivity', $data->id, $completiontime);
     ```
   * In `h5pactivity_update_instance()`, calls the same helper after saving the record.

3. **Timeline / My overview callback**

   * Implements `mod_h5pactivity_core_calendar_provide_event_action()` so H5P due‐date events are included (and actionable) in the Timeline block.

### How to test

1. **Purge caches**: *Site admin ▶ Development ▶ Purge caches*.
2. **Run cron** (or wait for your normal schedule).
3. Create or edit an H5P activity with a “Expected completion” date → verify it appears in:

   * Course **Calendar**
   * **Upcoming events** block
   * **Timeline** (Dashboard ▶ My overview)

Existing H5P activities can be bulk‐refreshed via:

```bash
php admin/cli/purge_caches.php
php admin/cli/cron.php
```

or by running the one‐off CLI script provided in the patch.